### PR TITLE
Add Rust enterprise type programming skill guide

### DIFF
--- a/.claude/skills/rust-type-programming.md
+++ b/.claude/skills/rust-type-programming.md
@@ -1,0 +1,113 @@
+# Rust Enterprise Type Programming Guide
+
+엔터프라이즈급 러스트 타입 프로그래밍을 위한 엄격한 가이드입니다.
+
+## 원칙
+
+- **타입 안전성 우선**: 컴파일 타임에 최대한 많은 에러를 잡습니다
+- **명시적 타입**: 타입 추론에 의존하기보다 명시적으로 선언합니다
+- **불변성 기본**: 가변성은 명시적으로만 사용합니다
+- **에러 타입화**: 모든 에러를 타입으로 표현합니다
+
+## 가이드 레퍼런스
+
+### 1. 타입 안전성
+[가이드 문서](.claude/skills/rust-type-programming/guides/type-safety.md)
+
+핵심 주제:
+- Newtype 패턴으로 타입 레벨 보장
+- Phantom Types로 상태 타입화
+- 타입 레벨 불변조건 표현
+- Zero-cost abstractions
+
+### 2. 에러 핸들링
+[가이드 문서](.claude/skills/rust-type-programming/guides/error-handling.md)
+
+핵심 주제:
+- 커스텀 에러 타입 설계
+- thiserror와 anyhow 활용
+- Result 타입 체이닝
+- 에러 컨텍스트 전파
+
+### 3. 타입 주도 설계
+[가이드 문서](.claude/skills/rust-type-programming/guides/type-driven-design.md)
+
+핵심 주제:
+- 불가능한 상태를 표현 불가능하게
+- Builder 패턴의 타입 상태
+- Typestate 패턴
+- API 설계 시 타입 활용
+
+### 4. 제네릭 & 트레이트
+[가이드 문서](.claude/skills/rust-type-programming/guides/generics-traits.md)
+
+핵심 주제:
+- 트레이트 바운드 설계
+- Associated Types vs Generic Parameters
+- Trait Objects vs Static Dispatch
+- 고급 트레이트 패턴
+
+### 5. 스마트 포인터 & 라이프타임
+[가이드 문서](.claude/skills/rust-type-programming/guides/ownership-lifetimes.md)
+
+핵심 주제:
+- 라이프타임 명시적 선언
+- 스마트 포인터 선택 가이드
+- Interior Mutability 패턴
+- Arc, Rc, RefCell 활용
+
+### 6. 매크로 & 코드 생성
+[가이드 문서](.claude/skills/rust-type-programming/guides/macros-codegen.md)
+
+핵심 주제:
+- Derive 매크로 활용
+- Procedural 매크로 패턴
+- 타입 안전한 DSL 설계
+- compile_error! 활용
+
+## 코드 리뷰 체크리스트
+
+코드 작성 시 다음을 확인하세요:
+
+- [ ] 모든 공개 함수에 명시적 타입 선언
+- [ ] unwrap() 대신 적절한 에러 핸들링
+- [ ] Newtype으로 도메인 타입 래핑
+- [ ] 가변 참조 최소화
+- [ ] 트레이트 바운드 명시
+- [ ] 라이프타임 파라미터 문서화
+- [ ] panic 발생 가능성 문서화
+- [ ] 타입 불변조건 주석 작성
+
+## 금지 패턴
+
+다음 패턴은 엔터프라이즈 코드에서 피해야 합니다:
+
+```rust
+// ❌ 타입 숨김
+fn process(data: &str) -> String
+
+// ✅ 명시적 타입
+fn process(data: UserId) -> Result<UserProfile, ProcessError>
+
+// ❌ unwrap 남용
+let value = result.unwrap();
+
+// ✅ 명시적 에러 처리
+let value = result.map_err(|e| ProcessError::from(e))?;
+
+// ❌ 프리미티브 타입 직접 사용
+fn transfer(amount: f64, account: String)
+
+// ✅ Newtype 사용
+fn transfer(amount: Money, account: AccountId) -> Result<Receipt, TransferError>
+```
+
+## 적용 방법
+
+이 가이드를 코드에 적용할 때:
+
+1. 먼저 도메인 타입 정의부터 시작
+2. 에러 타입을 명시적으로 설계
+3. 공개 API의 타입 시그니처 먼저 작성
+4. 구현은 타입이 강제하는 대로
+5. 컴파일러가 불가능한 상태를 거부하도록

--- a/.claude/skills/rust-type-programming/guides/error-handling.md
+++ b/.claude/skills/rust-type-programming/guides/error-handling.md
@@ -1,0 +1,566 @@
+# 에러 핸들링 패턴
+
+## 개요
+
+엔터프라이즈 애플리케이션에서 에러 핸들링은 타입 시스템의 핵심입니다.
+모든 에러는 타입으로 표현되고, 명시적으로 처리되어야 합니다.
+
+## 원칙
+
+1. **Never panic in library code**: 라이브러리는 panic하지 않고 Result를 반환
+2. **타입화된 에러**: String 대신 구조화된 에러 타입
+3. **컨텍스트 보존**: 에러 체인을 통해 원인 추적
+4. **복구 가능성 구분**: 복구 가능/불가능 에러를 타입으로 구분
+
+## 1. 커스텀 에러 타입 설계
+
+### thiserror 사용
+
+```rust
+use thiserror::Error;
+
+/// 사용자 서비스의 모든 에러
+#[derive(Debug, Error)]
+pub enum UserServiceError {
+    #[error("User not found: {user_id}")]
+    NotFound { user_id: String },
+
+    #[error("User already exists: {email}")]
+    AlreadyExists { email: String },
+
+    #[error("Invalid email format: {email}")]
+    InvalidEmail { email: String },
+
+    #[error("Database error: {0}")]
+    Database(#[from] DatabaseError),
+
+    #[error("Validation error: {0}")]
+    Validation(#[from] ValidationError),
+
+    #[error("Permission denied: {action} requires {required_role}")]
+    PermissionDenied {
+        action: String,
+        required_role: String,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum DatabaseError {
+    #[error("Connection failed: {0}")]
+    ConnectionFailed(String),
+
+    #[error("Query failed: {0}")]
+    QueryFailed(String),
+
+    #[error("Transaction failed: {0}")]
+    TransactionFailed(String),
+}
+
+#[derive(Debug, Error)]
+pub enum ValidationError {
+    #[error("Field '{field}' is required")]
+    Required { field: String },
+
+    #[error("Field '{field}' is too long: {length} > {max}")]
+    TooLong {
+        field: String,
+        length: usize,
+        max: usize,
+    },
+
+    #[error("Field '{field}' is too short: {length} < {min}")]
+    TooShort {
+        field: String,
+        length: usize,
+        min: usize,
+    },
+}
+```
+
+### 에러 계층 구조
+
+```rust
+use thiserror::Error;
+
+/// 애플리케이션 레벨 에러
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("User service error")]
+    UserService(#[from] UserServiceError),
+
+    #[error("Payment service error")]
+    PaymentService(#[from] PaymentServiceError),
+
+    #[error("Authentication error")]
+    Auth(#[from] AuthError),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+/// 도메인별 에러를 명시적으로 분리
+#[derive(Debug, Error)]
+pub enum PaymentServiceError {
+    #[error("Insufficient funds: required {required}, available {available}")]
+    InsufficientFunds { required: u64, available: u64 },
+
+    #[error("Payment gateway error: {0}")]
+    Gateway(String),
+
+    #[error("Invalid payment method")]
+    InvalidMethod,
+}
+
+#[derive(Debug, Error)]
+pub enum AuthError {
+    #[error("Invalid credentials")]
+    InvalidCredentials,
+
+    #[error("Token expired")]
+    TokenExpired,
+
+    #[error("Token invalid: {0}")]
+    TokenInvalid(String),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+}
+```
+
+## 2. Result 타입 체이닝
+
+### 기본 패턴
+
+```rust
+use std::fs::File;
+use std::io::{self, Read};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("Failed to read config file: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("Failed to parse config: {0}")]
+    Parse(#[from] serde_json::Error),
+
+    #[error("Invalid config: {0}")]
+    Invalid(String),
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Config {
+    pub port: u16,
+    pub host: String,
+    pub database_url: String,
+}
+
+impl Config {
+    pub fn from_file(path: &str) -> Result<Self, ConfigError> {
+        let mut file = File::open(path)?; // io::Error -> ConfigError
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?; // io::Error -> ConfigError
+
+        let config: Config = serde_json::from_str(&contents)?; // serde_json::Error -> ConfigError
+
+        // 추가 검증
+        if config.port == 0 {
+            return Err(ConfigError::Invalid("Port cannot be 0".to_string()));
+        }
+
+        Ok(config)
+    }
+}
+```
+
+### map_err로 에러 변환
+
+```rust
+use std::num::ParseIntError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("Invalid format: {0}")]
+    InvalidFormat(String),
+
+    #[error("Number parse error: {0}")]
+    NumberParse(#[from] ParseIntError),
+}
+
+fn parse_id(s: &str) -> Result<u64, ParseError> {
+    if s.is_empty() {
+        return Err(ParseError::InvalidFormat("ID cannot be empty".to_string()));
+    }
+
+    s.parse::<u64>()
+        .map_err(|e| ParseError::NumberParse(e))
+}
+
+// 또는 더 간단하게 From trait 활용
+fn parse_id_simple(s: &str) -> Result<u64, ParseError> {
+    if s.is_empty() {
+        return Err(ParseError::InvalidFormat("ID cannot be empty".to_string()));
+    }
+
+    Ok(s.parse::<u64>()?) // From<ParseIntError> 자동 변환
+}
+```
+
+## 3. 컨텍스트 전파
+
+### anyhow 사용 (애플리케이션 레벨)
+
+```rust
+use anyhow::{Context, Result};
+
+/// 라이브러리 코드는 구체적 에러 타입 사용
+pub fn read_user_from_db(id: &str) -> Result<User, UserServiceError> {
+    // ...
+}
+
+/// 애플리케이션 코드는 anyhow::Result 사용
+pub fn process_user_request(id: &str) -> anyhow::Result<String> {
+    let user = read_user_from_db(id)
+        .context("Failed to read user from database")?;
+
+    let profile = user.get_profile()
+        .context(format!("Failed to get profile for user {}", id))?;
+
+    Ok(profile.to_json())
+}
+```
+
+### 명시적 컨텍스트 타입
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("Operation '{operation}' failed at {location}: {source}")]
+pub struct ContextError {
+    operation: String,
+    location: String,
+    #[source]
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl ContextError {
+    pub fn new(
+        operation: impl Into<String>,
+        location: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            operation: operation.into(),
+            location: location.into(),
+            source: Box::new(source),
+        }
+    }
+}
+
+// 사용 예시
+fn save_user(user: &User) -> Result<(), ContextError> {
+    database::insert(user).map_err(|e| {
+        ContextError::new("save_user", "user_service.rs:123", e)
+    })?;
+
+    Ok(())
+}
+```
+
+## 4. 복구 가능성 구분
+
+### Recoverable vs Fatal
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceError {
+    /// 복구 가능한 에러들
+    #[error("Temporary error: {0}")]
+    Temporary(String),
+
+    #[error("Retry exhausted: {0}")]
+    RetryExhausted(String),
+
+    /// 복구 불가능한 에러들
+    #[error("Fatal error: {0}")]
+    Fatal(String),
+
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+}
+
+impl ServiceError {
+    /// 재시도 가능한 에러인지 확인
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, ServiceError::Temporary(_))
+    }
+
+    /// 치명적 에러인지 확인
+    pub fn is_fatal(&self) -> bool {
+        matches!(
+            self,
+            ServiceError::Fatal(_) | ServiceError::Configuration(_)
+        )
+    }
+}
+
+// 재시도 로직
+pub async fn with_retry<F, T, E>(
+    mut f: F,
+    max_retries: usize,
+) -> Result<T, ServiceError>
+where
+    F: FnMut() -> Result<T, ServiceError>,
+{
+    let mut attempts = 0;
+
+    loop {
+        match f() {
+            Ok(result) => return Ok(result),
+            Err(e) if e.is_fatal() => return Err(e),
+            Err(e) if attempts >= max_retries => {
+                return Err(ServiceError::RetryExhausted(format!(
+                    "Failed after {} attempts: {}",
+                    max_retries, e
+                )));
+            }
+            Err(ServiceError::Temporary(_)) => {
+                attempts += 1;
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+```
+
+## 5. 에러 타입 별칭
+
+```rust
+// 도메인별 Result 타입 별칭
+pub type UserResult<T> = Result<T, UserServiceError>;
+pub type PaymentResult<T> = Result<T, PaymentServiceError>;
+pub type AuthResult<T> = Result<T, AuthError>;
+
+// 사용 예시
+pub fn create_user(email: &str, password: &str) -> UserResult<User> {
+    // UserServiceError를 반복해서 쓸 필요 없음
+    validate_email(email)?;
+    validate_password(password)?;
+
+    let user = User::new(email, password);
+    save_to_db(&user)?;
+
+    Ok(user)
+}
+```
+
+## 6. Option vs Result
+
+### Option 사용 경우
+
+```rust
+// ✅ 값이 없는 것이 정상적인 경우
+pub fn find_user_by_email(email: &str) -> Option<User> {
+    // 사용자가 없을 수 있음 (에러 아님)
+}
+
+// ✅ 캐시 조회
+pub fn get_from_cache(key: &str) -> Option<String> {
+    // 캐시 미스는 정상 상황
+}
+```
+
+### Result 사용 경우
+
+```rust
+// ✅ 실패 원인이 중요한 경우
+pub fn load_config(path: &str) -> Result<Config, ConfigError> {
+    // 파일이 없는지, 파싱 실패인지 등 원인이 중요
+}
+
+// ✅ 검증 실패
+pub fn validate_email(email: &str) -> Result<(), ValidationError> {
+    // 왜 실패했는지 알아야 함
+}
+```
+
+### Option to Result 변환
+
+```rust
+pub fn get_user_or_error(id: &str) -> Result<User, UserServiceError> {
+    find_user(id).ok_or_else(|| UserServiceError::NotFound {
+        user_id: id.to_string(),
+    })
+}
+```
+
+## 7. 에러 핸들링 패턴
+
+### Early Return 패턴
+
+```rust
+pub fn process_payment(
+    user_id: &str,
+    amount: u64,
+) -> Result<Receipt, PaymentServiceError> {
+    // 조기 리턴으로 에러 처리
+    let user = get_user(user_id)?;
+    let account = user.account()?;
+
+    if account.balance() < amount {
+        return Err(PaymentServiceError::InsufficientFunds {
+            required: amount,
+            available: account.balance(),
+        });
+    }
+
+    let transaction = account.deduct(amount)?;
+    let receipt = generate_receipt(&transaction)?;
+
+    Ok(receipt)
+}
+```
+
+### Match 패턴
+
+```rust
+pub fn handle_user_creation(email: &str) -> Result<User, AppError> {
+    match create_user(email) {
+        Ok(user) => {
+            log::info!("User created: {}", email);
+            Ok(user)
+        }
+        Err(UserServiceError::AlreadyExists { email }) => {
+            log::warn!("User already exists: {}", email);
+            // 이미 존재하는 사용자 반환
+            get_user_by_email(&email).map_err(AppError::from)
+        }
+        Err(e) => {
+            log::error!("Failed to create user: {}", e);
+            Err(AppError::from(e))
+        }
+    }
+}
+```
+
+### and_then 체이닝
+
+```rust
+pub fn get_user_profile(user_id: &str) -> UserResult<Profile> {
+    get_user(user_id)
+        .and_then(|user| user.verify())
+        .and_then(|user| user.load_profile())
+        .and_then(|profile| profile.enrich())
+}
+```
+
+## 8. 에러 로깅
+
+```rust
+use tracing::{error, warn, info};
+
+pub fn process_with_logging(id: &str) -> Result<(), AppError> {
+    info!("Processing item: {}", id);
+
+    match process_item(id) {
+        Ok(()) => {
+            info!("Successfully processed item: {}", id);
+            Ok(())
+        }
+        Err(e) if e.is_retryable() => {
+            warn!("Retryable error for item {}: {}", id, e);
+            Err(e)
+        }
+        Err(e) => {
+            error!("Fatal error for item {}: {:#}", id, e);
+            // {:#} 는 에러 체인 전체를 출력
+            Err(e)
+        }
+    }
+}
+```
+
+## 9. 테스트용 에러
+
+```rust
+#[cfg(test)]
+impl UserServiceError {
+    /// 테스트용 헬퍼 메서드
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, UserServiceError::NotFound { .. })
+    }
+
+    pub fn is_already_exists(&self) -> bool {
+        matches!(self, UserServiceError::AlreadyExists { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_not_found() {
+        let result = get_user("nonexistent");
+        assert!(result.is_err());
+
+        let error = result.unwrap_err();
+        assert!(error.is_not_found());
+    }
+}
+```
+
+## 10. Never Type과 Infallible
+
+```rust
+use std::convert::Infallible;
+
+// 절대 실패하지 않는 함수
+pub fn always_succeeds() -> Result<String, Infallible> {
+    Ok("Success".to_string())
+}
+
+// 사용 시
+fn use_infallible() {
+    let result = always_succeeds();
+    // unwrap이 안전함 (절대 실패하지 않으므로)
+    let value = result.unwrap();
+}
+
+// 타입 시스템으로 성공을 보장
+pub fn process_infallible<E>(
+    result: Result<String, Infallible>,
+) -> Result<String, E> {
+    match result {
+        Ok(s) => Ok(s),
+        // Err 케이스는 실제로 발생할 수 없음
+        Err(never) => match never {},
+    }
+}
+```
+
+## 체크리스트
+
+에러 핸들링 체크리스트:
+
+- [ ] unwrap(), expect() 사용 금지 (테스트 제외)
+- [ ] panic!() 사용 금지 (라이브러리 코드)
+- [ ] String 에러 대신 구조화된 에러 타입
+- [ ] 모든 에러에 충분한 컨텍스트 정보
+- [ ] 에러 타입에 #[derive(Debug, Error)] 적용
+- [ ] 복구 가능한 에러와 치명적 에러 구분
+- [ ] 에러 체인 보존 (#[from], #[source])
+- [ ] 도메인별 에러 타입 분리
+- [ ] 에러 처리 로직에 로깅 추가
+- [ ] 공개 API의 에러 타입 문서화
+
+## 참고 자료
+
+- [thiserror](https://docs.rs/thiserror/)
+- [anyhow](https://docs.rs/anyhow/)
+- [Error Handling in Rust](https://blog.burntsushi.net/rust-error-handling/)
+- [Rust Book - Error Handling](https://doc.rust-lang.org/book/ch09-00-error-handling.html)

--- a/.claude/skills/rust-type-programming/guides/generics-traits.md
+++ b/.claude/skills/rust-type-programming/guides/generics-traits.md
@@ -1,0 +1,657 @@
+# 제네릭 & 트레이트 활용 가이드
+
+## 개요
+
+제네릭과 트레이트는 러스트의 타입 시스템에서 가장 강력한 추상화 도구입니다.
+엔터프라이즈 코드에서는 타입 안전성을 유지하면서 재사용 가능한 코드를 작성하기 위해 필수적입니다.
+
+## 1. 트레이트 바운드 설계
+
+### 명시적 트레이트 바운드
+
+```rust
+use std::fmt::{Debug, Display};
+
+// ❌ 너무 관대함
+fn process<T>(value: T) {
+    // T에 대해 할 수 있는 게 거의 없음
+}
+
+// ✅ 필요한 바운드만 명시
+fn process<T: Debug + Clone>(value: T) -> T {
+    println!("Processing: {:?}", value);
+    value.clone()
+}
+
+// ✅ where 절로 가독성 향상
+fn complex_function<T, U, V>(a: T, b: U, c: V) -> Result<String, ProcessError>
+where
+    T: Debug + Display + Clone,
+    U: IntoIterator<Item = String>,
+    V: AsRef<str> + Into<String>,
+{
+    // 구현
+    Ok(format!("{}", a))
+}
+```
+
+### 트레이트 바운드 최소화
+
+```rust
+// ❌ 과도한 바운드
+fn print_items<T: Debug + Display + Clone + PartialEq>(items: Vec<T>) {
+    for item in items {
+        println!("{:?}", item); // Debug만 사용
+    }
+}
+
+// ✅ 필요한 것만
+fn print_items<T: Debug>(items: Vec<T>) {
+    for item in items {
+        println!("{:?}", item);
+    }
+}
+```
+
+### 조건부 트레이트 구현
+
+```rust
+use std::fmt::{self, Display};
+
+pub struct Wrapper<T> {
+    value: T,
+}
+
+// T가 Display를 구현하는 경우에만 Wrapper도 Display 구현
+impl<T: Display> Display for Wrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Wrapper({})", self.value)
+    }
+}
+
+// T가 Clone을 구현하는 경우에만 Wrapper도 Clone 구현
+impl<T: Clone> Clone for Wrapper<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+        }
+    }
+}
+```
+
+## 2. Associated Types vs Generic Parameters
+
+### Associated Types 사용 경우
+
+```rust
+// ✅ 트레이트 당 하나의 구체적인 타입이 있을 때
+pub trait Repository {
+    type Entity;
+    type Error;
+
+    fn find(&self, id: &str) -> Result<Self::Entity, Self::Error>;
+    fn save(&self, entity: &Self::Entity) -> Result<(), Self::Error>;
+    fn delete(&self, id: &str) -> Result<(), Self::Error>;
+}
+
+pub struct UserRepository {
+    // ...
+}
+
+impl Repository for UserRepository {
+    type Entity = User;
+    type Error = DatabaseError;
+
+    fn find(&self, id: &str) -> Result<User, DatabaseError> {
+        // 구현
+        Ok(User::default())
+    }
+
+    fn save(&self, entity: &User) -> Result<(), DatabaseError> {
+        // 구현
+        Ok(())
+    }
+
+    fn delete(&self, id: &str) -> Result<(), DatabaseError> {
+        // 구현
+        Ok(())
+    }
+}
+
+// ✅ 사용이 간단함
+fn process_repository<R: Repository>(repo: &R) -> Result<R::Entity, R::Error> {
+    repo.find("123")
+}
+```
+
+### Generic Parameters 사용 경우
+
+```rust
+// ✅ 여러 타입으로 구현 가능할 때
+pub trait Converter<Input, Output> {
+    fn convert(&self, input: Input) -> Output;
+}
+
+pub struct StringToIntConverter;
+
+impl Converter<String, i32> for StringToIntConverter {
+    fn convert(&self, input: String) -> i32 {
+        input.parse().unwrap_or(0)
+    }
+}
+
+impl Converter<String, f64> for StringToIntConverter {
+    fn convert(&self, input: String) -> f64 {
+        input.parse().unwrap_or(0.0)
+    }
+}
+
+// ✅ 여러 변환 지원
+fn use_converter() {
+    let converter = StringToIntConverter;
+    let int_val: i32 = converter.convert("42".to_string());
+    let float_val: f64 = converter.convert("42.5".to_string());
+}
+```
+
+### 혼합 사용
+
+```rust
+pub trait Serializer {
+    type Error;
+
+    fn serialize<T: serde::Serialize>(&self, value: &T) -> Result<Vec<u8>, Self::Error>;
+    fn deserialize<T: serde::DeserializeOwned>(&self, data: &[u8]) -> Result<T, Self::Error>;
+}
+
+pub struct JsonSerializer;
+
+impl Serializer for JsonSerializer {
+    type Error = serde_json::Error;
+
+    fn serialize<T: serde::Serialize>(&self, value: &T) -> Result<Vec<u8>, Self::Error> {
+        serde_json::to_vec(value)
+    }
+
+    fn deserialize<T: serde::DeserializeOwned>(&self, data: &[u8]) -> Result<T, Self::Error> {
+        serde_json::from_slice(data)
+    }
+}
+```
+
+## 3. Static Dispatch vs Dynamic Dispatch
+
+### Static Dispatch (제네릭)
+
+```rust
+// ✅ 성능이 중요할 때 - 제로 비용 추상화
+pub fn process_static<T: Display>(item: T) {
+    println!("{}", item);
+    // 컴파일러가 각 타입에 대해 별도 코드 생성
+    // 인라인 가능, 최적화 가능
+}
+
+// 사용
+fn use_static() {
+    process_static(42);        // process_static::<i32> 생성
+    process_static("hello");   // process_static::<&str> 생성
+}
+```
+
+### Dynamic Dispatch (Trait Objects)
+
+```rust
+// ✅ 런타임에 타입이 결정되거나, 여러 타입을 한 컬렉션에 담을 때
+pub fn process_dynamic(item: &dyn Display) {
+    println!("{}", item);
+    // 가상 함수 테이블(vtable)을 통한 호출
+    // 약간의 성능 비용 발생
+}
+
+// 이기종 컬렉션
+fn use_dynamic() {
+    let items: Vec<Box<dyn Display>> = vec![
+        Box::new(42),
+        Box::new("hello"),
+        Box::new(3.14),
+    ];
+
+    for item in items {
+        process_dynamic(item.as_ref());
+    }
+}
+```
+
+### 선택 가이드
+
+```rust
+// ✅ Static Dispatch 사용 경우
+// - 성능이 중요
+// - 컴파일 타임에 타입이 결정됨
+// - 코드 크기보다 속도가 중요
+
+pub fn fast_process<T: Debug>(value: T) {
+    // 인라인되어 최적화됨
+    println!("{:?}", value);
+}
+
+// ✅ Dynamic Dispatch 사용 경우
+// - 이기종 컬렉션 필요
+// - 플러그인 시스템
+// - 코드 크기가 중요 (하나의 구현만 생성)
+
+pub trait Plugin {
+    fn execute(&self);
+}
+
+pub struct PluginManager {
+    plugins: Vec<Box<dyn Plugin>>,
+}
+
+impl PluginManager {
+    pub fn add_plugin(&mut self, plugin: Box<dyn Plugin>) {
+        self.plugins.push(plugin);
+    }
+
+    pub fn run_all(&self) {
+        for plugin in &self.plugins {
+            plugin.execute();
+        }
+    }
+}
+```
+
+## 4. 고급 트레이트 패턴
+
+### Sealed Trait
+
+```rust
+// 외부에서 구현 불가능한 트레이트
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub trait CannotImplement: sealed::Sealed {
+    fn method(&self);
+}
+
+pub struct AllowedType;
+
+impl sealed::Sealed for AllowedType {}
+
+impl CannotImplement for AllowedType {
+    fn method(&self) {
+        println!("Allowed");
+    }
+}
+
+// ❌ 외부에서는 구현 불가
+// impl sealed::Sealed for MyType {}
+// impl CannotImplement for MyType { ... }
+```
+
+### Extension Trait
+
+```rust
+// 기존 타입에 메서드 추가
+pub trait StringExt {
+    fn is_valid_email(&self) -> bool;
+    fn truncate_to(&self, max_len: usize) -> String;
+}
+
+impl StringExt for String {
+    fn is_valid_email(&self) -> bool {
+        self.contains('@') && self.contains('.')
+    }
+
+    fn truncate_to(&self, max_len: usize) -> String {
+        if self.len() <= max_len {
+            self.clone()
+        } else {
+            format!("{}...", &self[..max_len - 3])
+        }
+    }
+}
+
+impl StringExt for str {
+    fn is_valid_email(&self) -> bool {
+        self.contains('@') && self.contains('.')
+    }
+
+    fn truncate_to(&self, max_len: usize) -> String {
+        if self.len() <= max_len {
+            self.to_string()
+        } else {
+            format!("{}...", &self[..max_len - 3])
+        }
+    }
+}
+
+// 사용
+fn use_extension() {
+    let email = "test@example.com".to_string();
+    println!("Is valid: {}", email.is_valid_email());
+    println!("Truncated: {}", email.truncate_to(10));
+}
+```
+
+### Marker Trait
+
+```rust
+use std::marker::PhantomData;
+
+// 마커 트레이트로 타입 속성 표시
+pub trait Validated {}
+
+pub struct Email<V> {
+    value: String,
+    _validated: PhantomData<V>,
+}
+
+pub struct Unvalidated;
+pub struct ValidatedMarker;
+
+impl Validated for ValidatedMarker {}
+
+impl Email<Unvalidated> {
+    pub fn new(value: String) -> Self {
+        Self {
+            value,
+            _validated: PhantomData,
+        }
+    }
+
+    pub fn validate(self) -> Result<Email<ValidatedMarker>, ValidationError> {
+        if !self.value.contains('@') {
+            return Err(ValidationError::InvalidFormat);
+        }
+
+        Ok(Email {
+            value: self.value,
+            _validated: PhantomData,
+        })
+    }
+}
+
+impl Email<ValidatedMarker> {
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+// 검증된 이메일만 받는 함수
+pub fn send_email<V: Validated>(email: Email<V>) {
+    println!("Sending to: {}", email.value());
+}
+```
+
+### Blanket Implementation
+
+```rust
+// 특정 트레이트를 구현하는 모든 타입에 대해 구현
+pub trait ToJson {
+    fn to_json(&self) -> String;
+}
+
+// serde::Serialize를 구현하는 모든 타입에 대해 ToJson 자동 구현
+impl<T: serde::Serialize> ToJson for T {
+    fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+}
+
+// 이제 모든 Serialize 타입이 to_json() 사용 가능
+#[derive(serde::Serialize)]
+struct User {
+    name: String,
+    age: u32,
+}
+
+fn use_blanket() {
+    let user = User {
+        name: "John".to_string(),
+        age: 30,
+    };
+    println!("{}", user.to_json()); // 자동으로 사용 가능
+}
+```
+
+## 5. 고급 제네릭 패턴
+
+### Higher-Kinded Types (HKT) 모방
+
+```rust
+// 러스트는 진정한 HKT가 없지만, 비슷하게 만들 수 있음
+
+pub trait Functor {
+    type Unwrapped;
+    type Wrapped<B>;
+
+    fn map<B, F>(self, f: F) -> Self::Wrapped<B>
+    where
+        F: FnOnce(Self::Unwrapped) -> B;
+}
+
+impl<A> Functor for Option<A> {
+    type Unwrapped = A;
+    type Wrapped<B> = Option<B>;
+
+    fn map<B, F>(self, f: F) -> Option<B>
+    where
+        F: FnOnce(A) -> B,
+    {
+        self.map(f)
+    }
+}
+
+impl<A, E> Functor for Result<A, E> {
+    type Unwrapped = A;
+    type Wrapped<B> = Result<B, E>;
+
+    fn map<B, F>(self, f: F) -> Result<B, E>
+    where
+        F: FnOnce(A) -> B,
+    {
+        self.map(f)
+    }
+}
+```
+
+### 타입 레벨 프로그래밍
+
+```rust
+use std::marker::PhantomData;
+
+// 타입 레벨 불리언
+pub struct True;
+pub struct False;
+
+pub trait Bool {
+    type Not: Bool;
+}
+
+impl Bool for True {
+    type Not = False;
+}
+
+impl Bool for False {
+    type Not = True;
+}
+
+// 타입 레벨 조건
+pub trait If {
+    type Then<T, F>;
+}
+
+impl If for True {
+    type Then<T, F> = T;
+}
+
+impl If for False {
+    type Then<T, F> = F;
+}
+
+// 사용 예시
+pub struct Config<IsProduction: Bool> {
+    _production: PhantomData<IsProduction>,
+}
+
+impl Config<True> {
+    pub fn database_url(&self) -> &str {
+        "prod-database-url"
+    }
+}
+
+impl Config<False> {
+    pub fn database_url(&self) -> &str {
+        "dev-database-url"
+    }
+}
+```
+
+## 6. 실전 패턴
+
+### Repository 패턴
+
+```rust
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Repository<T> {
+    type Error;
+
+    async fn find_by_id(&self, id: &str) -> Result<Option<T>, Self::Error>;
+    async fn find_all(&self) -> Result<Vec<T>, Self::Error>;
+    async fn save(&self, entity: &T) -> Result<(), Self::Error>;
+    async fn delete(&self, id: &str) -> Result<(), Self::Error>;
+}
+
+#[async_trait]
+impl Repository<User> for PostgresUserRepository {
+    type Error = DatabaseError;
+
+    async fn find_by_id(&self, id: &str) -> Result<Option<User>, DatabaseError> {
+        // 구현
+        Ok(None)
+    }
+
+    async fn find_all(&self) -> Result<Vec<User>, DatabaseError> {
+        Ok(Vec::new())
+    }
+
+    async fn save(&self, entity: &User) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+}
+```
+
+### Builder with Generics
+
+```rust
+pub struct Query<T, F = ()> {
+    table: String,
+    filters: F,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Query<T, ()> {
+    pub fn new(table: String) -> Self {
+        Self {
+            table,
+            filters: (),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, F> Query<T, F> {
+    pub fn filter<NewF>(self, filter: NewF) -> Query<T, (F, NewF)> {
+        Query {
+            table: self.table,
+            filters: (self.filters, filter),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn execute(self) -> Vec<T> {
+        // 실행 로직
+        Vec::new()
+    }
+}
+```
+
+### Type-safe ID
+
+```rust
+use std::marker::PhantomData;
+
+pub struct Id<T> {
+    value: String,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Id<T> {
+    pub fn new(value: String) -> Self {
+        Self {
+            value,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl<T> Clone for Id<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub struct User {
+    id: Id<User>,
+    name: String,
+}
+
+pub struct Post {
+    id: Id<Post>,
+    author_id: Id<User>, // 타입 안전한 참조
+    title: String,
+}
+
+// ❌ 컴파일 에러: 다른 타입의 ID는 비교 불가
+fn type_safe_ids() {
+    let user_id = Id::<User>::new("user-123".to_string());
+    let post_id = Id::<Post>::new("post-456".to_string());
+
+    // if user_id == post_id { } // 컴파일 에러
+}
+```
+
+## 체크리스트
+
+제네릭 & 트레이트 사용 체크리스트:
+
+- [ ] 트레이트 바운드는 필요한 것만 명시
+- [ ] Associated Types와 Generic Parameters 적절히 선택
+- [ ] Static/Dynamic dispatch 성능 트레이드오프 고려
+- [ ] Trait object는 Sized가 아님을 기억 (`?Sized`)
+- [ ] 제네릭 함수/타입에 충분한 문서화
+- [ ] 트레이트 경계 조건 명확히
+- [ ] PhantomData로 런타임 비용 없음 확인
+- [ ] 복잡한 제네릭은 타입 별칭으로 간소화
+
+## 참고 자료
+
+- [Rust Book - Generics](https://doc.rust-lang.org/book/ch10-00-generics.html)
+- [Rust Book - Traits](https://doc.rust-lang.org/book/ch10-02-traits.html)
+- [Trait Objects](https://doc.rust-lang.org/book/ch17-02-trait-objects.html)
+- [Advanced Traits](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html)

--- a/.claude/skills/rust-type-programming/guides/macros-codegen.md
+++ b/.claude/skills/rust-type-programming/guides/macros-codegen.md
@@ -1,0 +1,686 @@
+# 매크로 & 코드 생성 가이드
+
+## 개요
+
+매크로와 코드 생성은 반복적인 보일러플레이트를 줄이고 타입 안전성을 유지하는 강력한 도구입니다.
+엔터프라이즈 코드에서는 derive 매크로와 선언적 매크로를 적극 활용합니다.
+
+## 원칙
+
+1. **타입 안전성 유지**: 매크로로 생성된 코드도 타입 체크
+2. **명시적 에러**: 컴파일 타임에 명확한 에러 메시지
+3. **문서화**: 매크로 사용법을 명확히 문서화
+4. **최소 사용**: 매크로는 꼭 필요할 때만
+
+## 1. Derive 매크로 활용
+
+### 기본 Derive
+
+```rust
+// ✅ 필요한 trait만 derive
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct User {
+    pub id: String,
+    pub name: String,
+    pub email: String,
+}
+
+// ✅ Hash는 Eq가 있을 때만
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UserId(String);
+
+// ✅ 순서 비교가 필요할 때
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Priority(u8);
+
+// ✅ Default로 기본값 제공
+#[derive(Debug, Clone, Default)]
+pub struct Config {
+    pub host: String,
+    pub port: u16,
+}
+```
+
+### Serde Derive
+
+```rust
+use serde::{Deserialize, Serialize};
+
+// ✅ 직렬화/역직렬화
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiResponse {
+    pub status: String,
+    pub data: Option<String>,
+}
+
+// ✅ 필드명 변경
+#[derive(Debug, Serialize, Deserialize)]
+pub struct User {
+    #[serde(rename = "userId")]
+    pub user_id: String,
+
+    #[serde(rename = "fullName")]
+    pub full_name: String,
+}
+
+// ✅ 기본값 제공
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub host: String,
+
+    #[serde(default = "default_port")]
+    pub port: u16,
+
+    #[serde(default)]
+    pub timeout: u64,
+}
+
+fn default_port() -> u16 {
+    8080
+}
+
+// ✅ Skip 필드
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Session {
+    pub user_id: String,
+    pub created_at: i64,
+
+    #[serde(skip)]
+    pub internal_data: Vec<u8>,
+}
+
+// ✅ Enum 태깅
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Message {
+    Text { content: String },
+    Image { url: String, width: u32, height: u32 },
+    Video { url: String, duration: u32 },
+}
+```
+
+### thiserror Derive
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ServiceError {
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    #[error("Invalid input: {field} = {value}")]
+    InvalidInput { field: String, value: String },
+
+    #[error("Database error")]
+    Database(#[from] DatabaseError),
+
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Error)]
+#[error("Database connection failed: {reason}")]
+pub struct DatabaseError {
+    pub reason: String,
+}
+```
+
+### Custom Derive (Procedural Macro)
+
+```rust
+// 사용 예시 (매크로는 별도 크레이트로 정의)
+
+// ✅ Builder 패턴 자동 생성
+#[derive(Builder)]
+pub struct User {
+    name: String,
+    email: String,
+    #[builder(default)]
+    age: Option<u32>,
+}
+
+// 생성된 코드 사용
+fn use_builder() {
+    let user = UserBuilder::default()
+        .name("John".to_string())
+        .email("john@example.com".to_string())
+        .age(Some(30))
+        .build()
+        .unwrap();
+}
+
+// ✅ Validator 자동 생성
+#[derive(Validate)]
+pub struct RegisterForm {
+    #[validate(email)]
+    pub email: String,
+
+    #[validate(length(min = 8))]
+    pub password: String,
+
+    #[validate(range(min = 18, max = 120))]
+    pub age: u32,
+}
+```
+
+## 2. 선언적 매크로 (macro_rules!)
+
+### 기본 패턴
+
+```rust
+// ✅ 간단한 래퍼 매크로
+macro_rules! log_error {
+    ($($arg:tt)*) => {
+        eprintln!("[ERROR] {}", format!($($arg)*))
+    };
+}
+
+// 사용
+fn use_log() {
+    log_error!("Failed to connect: {}", "timeout");
+}
+
+// ✅ 여러 패턴 지원
+macro_rules! create_function {
+    // 인자 없음
+    ($name:ident) => {
+        fn $name() {
+            println!("Called {}", stringify!($name));
+        }
+    };
+
+    // 인자 있음
+    ($name:ident, $arg:ty) => {
+        fn $name(x: $arg) {
+            println!("Called {} with {:?}", stringify!($name), x);
+        }
+    };
+}
+
+// 사용
+create_function!(hello);
+create_function!(greet, String);
+```
+
+### 타입 안전한 DSL
+
+```rust
+// ✅ SQL 쿼리 빌더
+macro_rules! select {
+    ($table:ident where $field:ident = $value:expr) => {
+        format!(
+            "SELECT * FROM {} WHERE {} = '{}'",
+            stringify!($table),
+            stringify!($field),
+            $value
+        )
+    };
+
+    ($table:ident) => {
+        format!("SELECT * FROM {}", stringify!($table))
+    };
+}
+
+fn use_select() {
+    let query1 = select!(users);
+    let query2 = select!(users where id = "123");
+
+    println!("{}", query1);
+    println!("{}", query2);
+}
+
+// ✅ JSON 빌더
+macro_rules! json {
+    ({ $($key:tt : $value:tt),* $(,)? }) => {
+        {
+            let mut map = std::collections::HashMap::new();
+            $(
+                map.insert(
+                    String::from(stringify!($key)),
+                    json!($value)
+                );
+            )*
+            serde_json::Value::Object(
+                map.into_iter()
+                    .map(|(k, v)| (k, v))
+                    .collect()
+            )
+        }
+    };
+
+    ([ $($value:tt),* $(,)? ]) => {
+        serde_json::Value::Array(vec![
+            $(json!($value)),*
+        ])
+    };
+
+    ($value:expr) => {
+        serde_json::json!($value)
+    };
+}
+```
+
+### HashMap/HashSet 초기화
+
+```rust
+// ✅ 간편한 컬렉션 생성
+macro_rules! hashmap {
+    ($($key:expr => $value:expr),* $(,)?) => {
+        {
+            let mut map = std::collections::HashMap::new();
+            $(
+                map.insert($key, $value);
+            )*
+            map
+        }
+    };
+}
+
+macro_rules! hashset {
+    ($($value:expr),* $(,)?) => {
+        {
+            let mut set = std::collections::HashSet::new();
+            $(
+                set.insert($value);
+            )*
+            set
+        }
+    };
+}
+
+// 사용
+fn use_collections() {
+    let map = hashmap! {
+        "name" => "John",
+        "email" => "john@example.com",
+    };
+
+    let set = hashset! {
+        1, 2, 3, 4, 5
+    };
+}
+```
+
+## 3. 프로시저럴 매크로 패턴
+
+### Function-like 매크로
+
+```rust
+// 정의 (별도 크레이트)
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn make_answer(_item: TokenStream) -> TokenStream {
+    "fn answer() -> u32 { 42 }".parse().unwrap()
+}
+
+// 사용
+make_answer!();
+
+fn main() {
+    println!("The answer is: {}", answer());
+}
+```
+
+### Attribute 매크로
+
+```rust
+// 정의 (별도 크레이트)
+#[proc_macro_attribute]
+pub fn log_calls(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // 함수 호출 시 로그 추가
+    item
+}
+
+// 사용
+#[log_calls]
+fn important_function(x: i32) -> i32 {
+    x * 2
+}
+```
+
+### Derive 매크로
+
+```rust
+// 정의 (별도 크레이트)
+#[proc_macro_derive(Builder, attributes(builder))]
+pub fn derive_builder(input: TokenStream) -> TokenStream {
+    // Builder 패턴 코드 생성
+    input
+}
+
+// 사용
+#[derive(Builder)]
+struct User {
+    name: String,
+    #[builder(default)]
+    age: Option<u32>,
+}
+```
+
+## 4. 컴파일 타임 검증
+
+### static_assertions
+
+```rust
+use static_assertions::*;
+
+// ✅ 컴파일 타임 크기 검증
+assert_eq_size!(u64, [u8; 8]);
+assert_eq_size!(Option<&str>, &str);
+
+// ✅ trait 구현 확인
+assert_impl_all!(String: Clone, Send, Sync);
+assert_not_impl_any!(User: Copy);
+
+// ✅ 상수 검증
+const MAX_SIZE: usize = 100;
+const_assert!(MAX_SIZE < 1000);
+const_assert!(MAX_SIZE > 0);
+
+pub struct Buffer {
+    data: [u8; MAX_SIZE],
+}
+
+// ✅ 타입 속성 검증
+assert_eq_align!(u64, u64);
+```
+
+### compile_error!
+
+```rust
+// ✅ 조건부 컴파일 에러
+#[cfg(all(feature = "async", feature = "sync"))]
+compile_error!("Cannot enable both 'async' and 'sync' features");
+
+// ✅ 매크로 내부 검증
+macro_rules! validate_size {
+    ($size:expr) => {
+        if $size > 1024 {
+            compile_error!("Size must be <= 1024");
+        }
+    };
+}
+
+// ❌ 컴파일 에러
+// validate_size!(2048);
+```
+
+### cfg 조건부 컴파일
+
+```rust
+// ✅ OS별 코드
+#[cfg(target_os = "linux")]
+fn platform_specific() {
+    println!("Running on Linux");
+}
+
+#[cfg(target_os = "windows")]
+fn platform_specific() {
+    println!("Running on Windows");
+}
+
+// ✅ 피처 플래그
+#[cfg(feature = "advanced")]
+pub mod advanced {
+    pub fn advanced_feature() {
+        println!("Advanced feature enabled");
+    }
+}
+
+// ✅ 테스트 전용 코드
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_something() {
+        assert_eq!(2 + 2, 4);
+    }
+}
+
+// ✅ 디버그/릴리스 구분
+#[cfg(debug_assertions)]
+fn debug_only() {
+    println!("Debug mode");
+}
+
+#[cfg(not(debug_assertions))]
+fn debug_only() {
+    // 릴리스에서는 아무것도 안 함
+}
+```
+
+## 5. 코드 생성 도구
+
+### build.rs
+
+```rust
+// build.rs - 빌드 시점 코드 생성
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("generated.rs");
+    let mut f = File::create(&dest_path).unwrap();
+
+    // 코드 생성
+    writeln!(
+        f,
+        r#"
+        pub const BUILD_TIME: &str = "{}";
+        pub const VERSION: &str = "{}";
+        "#,
+        chrono::Utc::now().to_rfc3339(),
+        env!("CARGO_PKG_VERSION")
+    )
+    .unwrap();
+
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+// main.rs에서 사용
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+fn main() {
+    println!("Built at: {}", BUILD_TIME);
+    println!("Version: {}", VERSION);
+}
+```
+
+### include_str! / include_bytes!
+
+```rust
+// ✅ 파일 내용을 컴파일 타임에 포함
+pub const SQL_SCHEMA: &str = include_str!("schema.sql");
+pub const DEFAULT_CONFIG: &str = include_str!("config.toml");
+pub const LOGO_PNG: &[u8] = include_bytes!("logo.png");
+
+fn use_included() {
+    println!("Schema:\n{}", SQL_SCHEMA);
+}
+```
+
+### concat! / stringify!
+
+```rust
+// ✅ 문자열 결합
+const API_URL: &str = concat!(
+    "https://",
+    env!("API_HOST"),
+    "/api/v1"
+);
+
+// ✅ 식을 문자열로
+macro_rules! assert_with_message {
+    ($condition:expr) => {
+        if !$condition {
+            panic!(
+                "Assertion failed: {}",
+                stringify!($condition)
+            );
+        }
+    };
+}
+```
+
+## 6. 실전 패턴
+
+### 열거형 문자열 변환
+
+```rust
+macro_rules! enum_str {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $($(#[$variant_meta:meta])* $variant:ident),* $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        $vis enum $name {
+            $($(#[$variant_meta])* $variant),*
+        }
+
+        impl $name {
+            pub fn as_str(&self) -> &'static str {
+                match self {
+                    $(Self::$variant => stringify!($variant)),*
+                }
+            }
+
+            pub fn from_str(s: &str) -> Option<Self> {
+                match s {
+                    $(stringify!($variant) => Some(Self::$variant),)*
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+// 사용
+enum_str! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum Status {
+        Active,
+        Inactive,
+        Pending,
+    }
+}
+
+fn use_enum_str() {
+    let status = Status::Active;
+    println!("Status: {}", status.as_str());
+
+    let parsed = Status::from_str("Pending");
+    assert_eq!(parsed, Some(Status::Pending));
+}
+```
+
+### 테스트 헬퍼
+
+```rust
+#[cfg(test)]
+macro_rules! assert_ok {
+    ($result:expr) => {
+        match $result {
+            Ok(val) => val,
+            Err(e) => panic!("Expected Ok, got Err: {:?}", e),
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! assert_err {
+    ($result:expr) => {
+        match $result {
+            Ok(val) => panic!("Expected Err, got Ok: {:?}", val),
+            Err(e) => e,
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_macros() {
+        let result: Result<i32, String> = Ok(42);
+        let value = assert_ok!(result);
+        assert_eq!(value, 42);
+
+        let error_result: Result<i32, String> = Err("error".to_string());
+        let error = assert_err!(error_result);
+        assert_eq!(error, "error");
+    }
+}
+```
+
+### lazy_static / once_cell
+
+```rust
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+// ✅ 전역 상태 초기화
+static GLOBAL_CONFIG: Lazy<HashMap<String, String>> = Lazy::new(|| {
+    let mut map = HashMap::new();
+    map.insert("api_key".to_string(), "secret".to_string());
+    map.insert("endpoint".to_string(), "https://api.example.com".to_string());
+    map
+});
+
+fn use_global() {
+    println!("API Key: {}", GLOBAL_CONFIG.get("api_key").unwrap());
+}
+
+// ✅ Regex 패턴 캐싱
+static EMAIL_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
+    regex::Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").unwrap()
+});
+
+fn is_valid_email(email: &str) -> bool {
+    EMAIL_REGEX.is_match(email)
+}
+```
+
+## 체크리스트
+
+매크로 & 코드 생성 체크리스트:
+
+- [ ] derive 매크로를 최대한 활용
+- [ ] 반복적인 보일러플레이트만 매크로화
+- [ ] 매크로 사용법을 문서화
+- [ ] 컴파일 에러 메시지가 명확한가
+- [ ] static_assertions로 컴파일 타임 검증
+- [ ] cfg로 조건부 컴파일 활용
+- [ ] build.rs는 꼭 필요할 때만
+- [ ] 매크로 확장 결과를 cargo expand로 확인
+
+## 도구
+
+```bash
+# 매크로 확장 결과 확인
+cargo install cargo-expand
+cargo expand
+
+# 매크로 디버깅
+cargo rustc -- -Z trace-macros
+
+# 프로시저럴 매크로 개발
+cargo new my-macro --lib
+# Cargo.toml에 [lib] proc-macro = true 추가
+```
+
+## 참고 자료
+
+- [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book/)
+- [Procedural Macros Workshop](https://github.com/dtolnay/proc-macro-workshop)
+- [cargo-expand](https://github.com/dtolnay/cargo-expand)
+- [static_assertions](https://docs.rs/static_assertions/)

--- a/.claude/skills/rust-type-programming/guides/ownership-lifetimes.md
+++ b/.claude/skills/rust-type-programming/guides/ownership-lifetimes.md
@@ -1,0 +1,699 @@
+# 소유권 & 라이프타임 가이드
+
+## 개요
+
+소유권과 라이프타임은 러스트의 메모리 안전성을 보장하는 핵심 개념입니다.
+엔터프라이즈 코드에서는 명시적이고 예측 가능한 소유권 관리가 중요합니다.
+
+## 원칙
+
+1. **소유권 명확화**: 누가 데이터를 소유하는지 항상 명확해야 함
+2. **차용 최소화**: 불필요한 차용을 피하고 소유권 이전을 고려
+3. **라이프타임 명시**: 컴파일러 추론에 의존하지 말고 명시적으로 선언
+4. **불변성 우선**: 가변 차용은 꼭 필요한 경우에만
+
+## 1. 소유권 패턴
+
+### 소유권 vs 차용
+
+```rust
+// ❌ 불필요한 차용
+fn process_string(s: &String) -> usize {
+    s.len()
+}
+
+// ✅ &str로 더 유연하게
+fn process_string(s: &str) -> usize {
+    s.len()
+}
+
+// ❌ 소유권 이전 후 다시 사용
+fn bad_ownership() {
+    let s = String::from("hello");
+    let len = consume_string(s);
+    // println!("{}", s); // 컴파일 에러
+}
+
+fn consume_string(s: String) -> usize {
+    s.len()
+}
+
+// ✅ 차용으로 해결
+fn good_ownership() {
+    let s = String::from("hello");
+    let len = borrow_string(&s);
+    println!("{}", s); // OK
+}
+
+fn borrow_string(s: &str) -> usize {
+    s.len()
+}
+```
+
+### Builder 패턴의 소유권
+
+```rust
+pub struct RequestBuilder {
+    url: String,
+    headers: Vec<(String, String)>,
+    body: Option<Vec<u8>>,
+}
+
+impl RequestBuilder {
+    pub fn new(url: String) -> Self {
+        Self {
+            url,
+            headers: Vec::new(),
+            body: None,
+        }
+    }
+
+    // self를 소유하여 체이닝 가능
+    pub fn header(mut self, key: String, value: String) -> Self {
+        self.headers.push((key, value));
+        self
+    }
+
+    // self를 소유하여 체이닝 가능
+    pub fn body(mut self, body: Vec<u8>) -> Self {
+        self.body = Some(body);
+        self
+    }
+
+    // 최종적으로 소유권 이전
+    pub fn build(self) -> Request {
+        Request {
+            url: self.url,
+            headers: self.headers,
+            body: self.body,
+        }
+    }
+}
+
+pub struct Request {
+    url: String,
+    headers: Vec<(String, String)>,
+    body: Option<Vec<u8>>,
+}
+
+// ✅ 사용
+fn use_builder() {
+    let request = RequestBuilder::new("https://api.example.com".to_string())
+        .header("Content-Type".to_string(), "application/json".to_string())
+        .body(b"{}".to_vec())
+        .build();
+}
+```
+
+## 2. 명시적 라이프타임
+
+### 기본 라이프타임 명시
+
+```rust
+// ❌ 라이프타임 생략 (컴파일러 추론)
+fn first_word(s: &str) -> &str {
+    s.split_whitespace().next().unwrap_or("")
+}
+
+// ✅ 명시적 라이프타임
+fn first_word<'a>(s: &'a str) -> &'a str {
+    s.split_whitespace().next().unwrap_or("")
+}
+```
+
+### 구조체의 라이프타임
+
+```rust
+// 참조를 포함하는 구조체는 항상 라이프타임 명시
+pub struct UserView<'a> {
+    name: &'a str,
+    email: &'a str,
+    created_at: &'a str,
+}
+
+impl<'a> UserView<'a> {
+    pub fn new(name: &'a str, email: &'a str, created_at: &'a str) -> Self {
+        Self {
+            name,
+            email,
+            created_at,
+        }
+    }
+
+    pub fn display(&self) -> String {
+        format!("{} <{}>", self.name, self.email)
+    }
+}
+
+// ✅ 사용
+fn use_view() {
+    let name = String::from("John");
+    let email = String::from("john@example.com");
+    let created = String::from("2024-01-01");
+
+    let view = UserView::new(&name, &email, &created);
+    println!("{}", view.display());
+}
+```
+
+### 복잡한 라이프타임 관계
+
+```rust
+// 여러 라이프타임 파라미터
+pub struct Context<'short, 'long: 'short> {
+    // 'long은 'short보다 오래 살아야 함
+    config: &'long Config,
+    request: &'short Request,
+}
+
+impl<'short, 'long: 'short> Context<'short, 'long> {
+    pub fn new(config: &'long Config, request: &'short Request) -> Self {
+        Self { config, request }
+    }
+
+    pub fn process(&self) -> Response {
+        // config와 request 모두 사용 가능
+        Response::default()
+    }
+}
+
+pub struct Config {
+    max_connections: usize,
+}
+
+pub struct Request {
+    path: String,
+}
+
+#[derive(Default)]
+pub struct Response {
+    status: u16,
+}
+```
+
+### 정적 라이프타임
+
+```rust
+// 'static은 프로그램 전체 수명
+pub const APP_NAME: &'static str = "MyApp";
+
+pub struct AppConfig {
+    // 'static 문자열 리터럴
+    name: &'static str,
+    version: &'static str,
+}
+
+impl AppConfig {
+    pub const fn new() -> Self {
+        Self {
+            name: "MyApp",
+            version: "1.0.0",
+        }
+    }
+}
+
+// ⚠️ 'static을 요구하는 것은 신중히
+pub fn register_callback(f: Box<dyn Fn() + 'static>) {
+    // 콜백이 프로그램 종료까지 살아야 함
+}
+```
+
+## 3. 스마트 포인터
+
+### Box<T> - 힙 할당
+
+```rust
+// ✅ 재귀 타입
+pub enum List {
+    Cons(i32, Box<List>),
+    Nil,
+}
+
+// ✅ 큰 데이터 이동
+pub struct LargeData {
+    buffer: [u8; 1024 * 1024], // 1MB
+}
+
+pub fn process_large_data() -> Box<LargeData> {
+    // 스택 오버플로우 방지
+    Box::new(LargeData {
+        buffer: [0; 1024 * 1024],
+    })
+}
+
+// ✅ Trait Object
+pub trait Handler {
+    fn handle(&self, request: &Request) -> Response;
+}
+
+pub struct Router {
+    handlers: Vec<Box<dyn Handler>>,
+}
+
+impl Router {
+    pub fn add_handler(&mut self, handler: Box<dyn Handler>) {
+        self.handlers.push(handler);
+    }
+}
+```
+
+### Rc<T> - 참조 카운팅 (단일 스레드)
+
+```rust
+use std::rc::Rc;
+
+pub struct Node {
+    value: i32,
+    children: Vec<Rc<Node>>,
+}
+
+impl Node {
+    pub fn new(value: i32) -> Rc<Self> {
+        Rc::new(Self {
+            value,
+            children: Vec::new(),
+        })
+    }
+
+    pub fn add_child(self: &mut Rc<Self>, child: Rc<Node>) {
+        // Rc::get_mut는 참조 카운트가 1일 때만 성공
+        if let Some(node) = Rc::get_mut(self) {
+            node.children.push(child);
+        }
+    }
+}
+
+// ✅ 그래프 구조
+fn use_rc() {
+    let root = Node::new(1);
+    let child1 = Node::new(2);
+    let child2 = Node::new(3);
+
+    // 여러 부모가 같은 자식을 가리킬 수 있음
+    let shared_child = Node::new(4);
+
+    // root가 child1, child2를 소유
+    // child1과 child2가 shared_child를 공유
+}
+```
+
+### Arc<T> - 원자적 참조 카운팅 (멀티 스레드)
+
+```rust
+use std::sync::Arc;
+use std::thread;
+
+pub struct SharedConfig {
+    pub api_key: String,
+    pub timeout: u64,
+}
+
+pub fn use_arc() {
+    let config = Arc::new(SharedConfig {
+        api_key: "secret".to_string(),
+        timeout: 30,
+    });
+
+    let mut handles = vec![];
+
+    for i in 0..3 {
+        let config_clone = Arc::clone(&config);
+        let handle = thread::spawn(move || {
+            println!("Thread {} using API key: {}", i, config_clone.api_key);
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+```
+
+### RefCell<T> - 내부 가변성 (Interior Mutability)
+
+```rust
+use std::cell::RefCell;
+
+pub struct Logger {
+    logs: RefCell<Vec<String>>,
+}
+
+impl Logger {
+    pub fn new() -> Self {
+        Self {
+            logs: RefCell::new(Vec::new()),
+        }
+    }
+
+    // &self인데도 내부 수정 가능
+    pub fn log(&self, message: String) {
+        self.logs.borrow_mut().push(message);
+    }
+
+    pub fn get_logs(&self) -> Vec<String> {
+        self.logs.borrow().clone()
+    }
+}
+
+// ⚠️ RefCell은 런타임 차용 규칙 검사
+// 동시에 가변/불변 차용하면 panic
+fn refcell_panic() {
+    let logger = Logger::new();
+    let logs_ref = logger.logs.borrow(); // 불변 차용
+
+    // panic! 동시에 가변 차용 시도
+    // logger.log("error".to_string());
+
+    drop(logs_ref); // 불변 차용 종료
+    logger.log("error".to_string()); // OK
+}
+```
+
+### Cow<T> - Clone on Write
+
+```rust
+use std::borrow::Cow;
+
+pub fn process_string(input: &str) -> Cow<str> {
+    if input.contains("bad") {
+        // 수정 필요 - 소유된 String 생성
+        Cow::Owned(input.replace("bad", "good"))
+    } else {
+        // 수정 불필요 - 차용만
+        Cow::Borrowed(input)
+    }
+}
+
+// ✅ 효율적인 조건부 복사
+fn use_cow() {
+    let s1 = "hello world";
+    let result1 = process_string(s1); // 차용만, 복사 없음
+
+    let s2 = "bad word";
+    let result2 = process_string(s2); // 복사 발생
+
+    println!("{}", result1);
+    println!("{}", result2);
+}
+```
+
+## 4. 스마트 포인터 조합
+
+### Arc<Mutex<T>> - 공유 가변 상태
+
+```rust
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+pub struct Counter {
+    value: Arc<Mutex<i32>>,
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Self {
+            value: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub fn increment(&self) {
+        let mut value = self.value.lock().unwrap();
+        *value += 1;
+    }
+
+    pub fn get(&self) -> i32 {
+        *self.value.lock().unwrap()
+    }
+
+    pub fn clone_handle(&self) -> Self {
+        Self {
+            value: Arc::clone(&self.value),
+        }
+    }
+}
+
+fn use_arc_mutex() {
+    let counter = Counter::new();
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let counter_clone = counter.clone_handle();
+        let handle = thread::spawn(move || {
+            counter_clone.increment();
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Final count: {}", counter.get()); // 10
+}
+```
+
+### Arc<RwLock<T>> - 읽기 우선 잠금
+
+```rust
+use std::sync::{Arc, RwLock};
+use std::thread;
+
+pub struct Cache {
+    data: Arc<RwLock<std::collections::HashMap<String, String>>>,
+}
+
+impl Cache {
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(std::collections::HashMap::new())),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<String> {
+        let data = self.data.read().unwrap();
+        data.get(key).cloned()
+    }
+
+    pub fn set(&self, key: String, value: String) {
+        let mut data = self.data.write().unwrap();
+        data.insert(key, value);
+    }
+
+    pub fn clone_handle(&self) -> Self {
+        Self {
+            data: Arc::clone(&self.data),
+        }
+    }
+}
+
+fn use_rwlock() {
+    let cache = Cache::new();
+
+    // 쓰기 스레드
+    {
+        let cache_clone = cache.clone_handle();
+        thread::spawn(move || {
+            cache_clone.set("key1".to_string(), "value1".to_string());
+        });
+    }
+
+    // 여러 읽기 스레드 (동시 실행 가능)
+    for i in 0..5 {
+        let cache_clone = cache.clone_handle();
+        thread::spawn(move || {
+            if let Some(value) = cache_clone.get("key1") {
+                println!("Thread {}: {}", i, value);
+            }
+        });
+    }
+}
+```
+
+### Rc<RefCell<T>> - 단일 스레드 공유 가변성
+
+```rust
+use std::rc::Rc;
+use std::cell::RefCell;
+
+pub struct Graph {
+    nodes: Vec<Rc<RefCell<Node>>>,
+}
+
+pub struct Node {
+    value: i32,
+    neighbors: Vec<Rc<RefCell<Node>>>,
+}
+
+impl Node {
+    pub fn new(value: i32) -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(Self {
+            value,
+            neighbors: Vec::new(),
+        }))
+    }
+
+    pub fn add_neighbor(&mut self, neighbor: Rc<RefCell<Node>>) {
+        self.neighbors.push(neighbor);
+    }
+}
+
+impl Graph {
+    pub fn new() -> Self {
+        Self { nodes: Vec::new() }
+    }
+
+    pub fn add_edge(&mut self, from: Rc<RefCell<Node>>, to: Rc<RefCell<Node>>) {
+        from.borrow_mut().add_neighbor(Rc::clone(&to));
+    }
+}
+
+fn use_graph() {
+    let mut graph = Graph::new();
+
+    let node1 = Node::new(1);
+    let node2 = Node::new(2);
+    let node3 = Node::new(3);
+
+    graph.add_edge(Rc::clone(&node1), Rc::clone(&node2));
+    graph.add_edge(Rc::clone(&node2), Rc::clone(&node3));
+    graph.add_edge(Rc::clone(&node3), Rc::clone(&node1)); // 순환 참조
+}
+```
+
+## 5. 선택 가이드
+
+```rust
+// ✅ 단일 소유권
+struct Data {
+    value: String, // 소유
+}
+
+// ✅ 차용 (짧은 수명)
+fn process(data: &Data) {
+    // 임시로 사용
+}
+
+// ✅ Box - 힙 할당, 큰 데이터, Trait Object
+fn use_box() -> Box<dyn std::error::Error> {
+    Box::new(std::io::Error::new(std::io::ErrorKind::Other, "error"))
+}
+
+// ✅ Rc - 단일 스레드 공유 소유권
+use std::rc::Rc;
+fn use_rc_data(data: Rc<Data>) {
+    let clone = Rc::clone(&data);
+    // 여러 곳에서 공유
+}
+
+// ✅ Arc - 멀티 스레드 공유 소유권
+use std::sync::Arc;
+fn use_arc_data(data: Arc<Data>) {
+    let clone = Arc::clone(&data);
+    std::thread::spawn(move || {
+        // 스레드 간 공유
+    });
+}
+
+// ✅ RefCell - 단일 스레드 내부 가변성
+use std::cell::RefCell;
+struct Container {
+    data: RefCell<Vec<String>>,
+}
+
+// ✅ Mutex - 멀티 스레드 가변성
+use std::sync::Mutex;
+struct ThreadSafeContainer {
+    data: Mutex<Vec<String>>,
+}
+
+// ✅ RwLock - 읽기 많고 쓰기 적을 때
+use std::sync::RwLock;
+struct ReadHeavyContainer {
+    data: RwLock<Vec<String>>,
+}
+```
+
+## 6. 안티패턴
+
+```rust
+// ❌ 불필요한 clone
+fn bad_clone() {
+    let s = String::from("hello");
+    process_owned(s.clone()); // 불필요한 복사
+    println!("{}", s);
+}
+
+fn process_owned(s: String) {
+    println!("{}", s);
+}
+
+// ✅ 차용 사용
+fn good_borrow() {
+    let s = String::from("hello");
+    process_borrowed(&s); // 복사 없음
+    println!("{}", s);
+}
+
+fn process_borrowed(s: &str) {
+    println!("{}", s);
+}
+
+// ❌ 과도한 RefCell
+struct BadDesign {
+    field1: RefCell<i32>,
+    field2: RefCell<String>,
+    field3: RefCell<Vec<u8>>,
+}
+
+// ✅ 전체를 RefCell로
+struct GoodDesign {
+    inner: RefCell<Inner>,
+}
+
+struct Inner {
+    field1: i32,
+    field2: String,
+    field3: Vec<u8>,
+}
+
+// ❌ Arc 남용
+fn bad_arc() {
+    let data = Arc::new(42);
+    process_arc(Arc::clone(&data)); // 단일 스레드인데 Arc 사용
+}
+
+fn process_arc(data: Arc<i32>) {
+    println!("{}", data);
+}
+
+// ✅ 그냥 참조
+fn good_ref() {
+    let data = 42;
+    process_ref(&data);
+}
+
+fn process_ref(data: &i32) {
+    println!("{}", data);
+}
+```
+
+## 체크리스트
+
+소유권 & 라이프타임 체크리스트:
+
+- [ ] 소유권 이전 vs 차용을 명확히 선택
+- [ ] &String 대신 &str 사용
+- [ ] &Vec<T> 대신 &[T] 사용
+- [ ] 라이프타임은 명시적으로 선언
+- [ ] Clone은 정말 필요할 때만
+- [ ] 스마트 포인터는 적재적소에
+- [ ] RefCell/Mutex는 꼭 필요한 경우만
+- [ ] 순환 참조 주의 (Weak 사용 고려)
+
+## 참고 자료
+
+- [Rust Book - Ownership](https://doc.rust-lang.org/book/ch04-00-understanding-ownership.html)
+- [Rust Book - Lifetimes](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html)
+- [Rust Book - Smart Pointers](https://doc.rust-lang.org/book/ch15-00-smart-pointers.html)
+- [Too Many Lists](https://rust-unofficial.github.io/too-many-lists/)

--- a/.claude/skills/rust-type-programming/guides/type-driven-design.md
+++ b/.claude/skills/rust-type-programming/guides/type-driven-design.md
@@ -1,0 +1,666 @@
+# 타입 주도 설계 (Type-Driven Design)
+
+## 개요
+
+타입 주도 설계는 타입 시스템을 활용하여 불가능한 상태를 표현할 수 없게 만드는 설계 방법론입니다.
+"If it compiles, it works"를 목표로 합니다.
+
+## 핵심 원칙
+
+**"Make Impossible States Impossible"**
+
+잘못된 상태를 만들 수 없도록 타입 시스템이 강제합니다.
+
+## 1. 불가능한 상태 제거
+
+### 나쁜 설계
+
+```rust
+// ❌ BAD: 모순된 상태가 가능
+pub struct User {
+    pub username: String,
+    pub email: String,
+    pub is_verified: bool,
+    pub verification_token: Option<String>, // 검증된 사용자도 토큰을 가질 수 있음!
+}
+
+// 문제: is_verified=true이면서 verification_token=Some인 상태 가능
+let invalid_user = User {
+    username: "john".to_string(),
+    email: "john@example.com".to_string(),
+    is_verified: true,
+    verification_token: Some("abc123".to_string()), // 모순!
+};
+```
+
+### 좋은 설계
+
+```rust
+// ✅ GOOD: 타입으로 상태 구분
+pub struct VerifiedUser {
+    pub username: String,
+    pub email: String,
+}
+
+pub struct UnverifiedUser {
+    pub username: String,
+    pub email: String,
+    pub verification_token: String, // 항상 존재
+}
+
+pub enum User {
+    Verified(VerifiedUser),
+    Unverified(UnverifiedUser),
+}
+
+impl User {
+    pub fn verify(self, token: &str) -> Result<VerifiedUser, VerificationError> {
+        match self {
+            User::Unverified(user) if user.verification_token == token => {
+                Ok(VerifiedUser {
+                    username: user.username,
+                    email: user.email,
+                })
+            }
+            User::Unverified(_) => Err(VerificationError::InvalidToken),
+            User::Verified(user) => Ok(user), // 이미 검증됨
+        }
+    }
+}
+
+// ✅ 불가능한 상태를 만들 수 없음
+```
+
+## 2. Typestate 패턴
+
+### HTTP Connection 상태 관리
+
+```rust
+use std::marker::PhantomData;
+
+// 상태 타입들
+pub struct Disconnected;
+pub struct Connected;
+pub struct Authenticated;
+
+pub struct HttpConnection<State> {
+    url: String,
+    _state: PhantomData<State>,
+}
+
+impl HttpConnection<Disconnected> {
+    pub fn new(url: String) -> Self {
+        Self {
+            url,
+            _state: PhantomData,
+        }
+    }
+
+    pub fn connect(self) -> Result<HttpConnection<Connected>, ConnectionError> {
+        println!("Connecting to {}", self.url);
+        // 실제 연결 로직
+        Ok(HttpConnection {
+            url: self.url,
+            _state: PhantomData,
+        })
+    }
+}
+
+impl HttpConnection<Connected> {
+    pub fn authenticate(
+        self,
+        credentials: &Credentials,
+    ) -> Result<HttpConnection<Authenticated>, AuthError> {
+        println!("Authenticating...");
+        // 인증 로직
+        Ok(HttpConnection {
+            url: self.url,
+            _state: PhantomData,
+        })
+    }
+
+    pub fn disconnect(self) -> HttpConnection<Disconnected> {
+        println!("Disconnecting...");
+        HttpConnection {
+            url: self.url,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl HttpConnection<Authenticated> {
+    pub fn send_request(&self, request: &Request) -> Response {
+        println!("Sending authenticated request to {}", self.url);
+        // 요청 전송
+        Response::default()
+    }
+
+    pub fn disconnect(self) -> HttpConnection<Disconnected> {
+        println!("Disconnecting...");
+        HttpConnection {
+            url: self.url,
+            _state: PhantomData,
+        }
+    }
+}
+
+// ✅ 사용 예시
+fn typestate_example() -> Result<(), Box<dyn std::error::Error>> {
+    let conn = HttpConnection::new("https://api.example.com".to_string());
+
+    // ❌ 컴파일 에러: Disconnected 상태에서는 send_request 불가
+    // conn.send_request(&request);
+
+    let conn = conn.connect()?;
+
+    // ❌ 컴파일 에러: Connected 상태에서는 send_request 불가
+    // conn.send_request(&request);
+
+    let conn = conn.authenticate(&credentials)?;
+
+    // ✅ OK: Authenticated 상태에서만 가능
+    conn.send_request(&request);
+
+    Ok(())
+}
+```
+
+### Builder의 Typestate
+
+```rust
+use std::marker::PhantomData;
+
+pub struct NoTitle;
+pub struct HasTitle;
+pub struct NoBody;
+pub struct HasBody;
+
+pub struct ArticleBuilder<Title, Body> {
+    title: Option<String>,
+    body: Option<String>,
+    tags: Vec<String>,
+    _title: PhantomData<Title>,
+    _body: PhantomData<Body>,
+}
+
+impl ArticleBuilder<NoTitle, NoBody> {
+    pub fn new() -> Self {
+        Self {
+            title: None,
+            body: None,
+            tags: Vec::new(),
+            _title: PhantomData,
+            _body: PhantomData,
+        }
+    }
+}
+
+impl<Body> ArticleBuilder<NoTitle, Body> {
+    pub fn title(self, title: String) -> ArticleBuilder<HasTitle, Body> {
+        ArticleBuilder {
+            title: Some(title),
+            body: self.body,
+            tags: self.tags,
+            _title: PhantomData,
+            _body: PhantomData,
+        }
+    }
+}
+
+impl<Title> ArticleBuilder<Title, NoBody> {
+    pub fn body(self, body: String) -> ArticleBuilder<Title, HasBody> {
+        ArticleBuilder {
+            title: self.title,
+            body: Some(body),
+            tags: self.tags,
+            _title: PhantomData,
+            _body: PhantomData,
+        }
+    }
+}
+
+impl<Title, Body> ArticleBuilder<Title, Body> {
+    pub fn tag(mut self, tag: String) -> Self {
+        self.tags.push(tag);
+        self
+    }
+}
+
+pub struct Article {
+    title: String,
+    body: String,
+    tags: Vec<String>,
+}
+
+// build는 모든 필수 필드가 설정된 경우에만 가능
+impl ArticleBuilder<HasTitle, HasBody> {
+    pub fn build(self) -> Article {
+        Article {
+            title: self.title.unwrap(), // 타입 시스템이 Some 보장
+            body: self.body.unwrap(),   // 타입 시스템이 Some 보장
+            tags: self.tags,
+        }
+    }
+}
+
+// ✅ 사용 예시
+fn builder_example() {
+    let article = ArticleBuilder::new()
+        .title("Rust Type System".to_string())
+        .body("Content here...".to_string())
+        .tag("rust".to_string())
+        .tag("programming".to_string())
+        .build(); // ✅ OK
+
+    // ❌ 컴파일 에러: title이 없음
+    // let article = ArticleBuilder::new()
+    //     .body("Content".to_string())
+    //     .build();
+}
+```
+
+## 3. API 설계 시 타입 활용
+
+### 검색 쿼리 빌더
+
+```rust
+pub struct SearchQuery {
+    text: String,
+    filters: Vec<Filter>,
+    sort: Option<SortBy>,
+    page: Page,
+}
+
+pub struct SearchQueryBuilder {
+    text: Option<String>,
+    filters: Vec<Filter>,
+    sort: Option<SortBy>,
+    page: Page,
+}
+
+impl SearchQueryBuilder {
+    pub fn new() -> Self {
+        Self {
+            text: None,
+            filters: Vec::new(),
+            sort: None,
+            page: Page::default(),
+        }
+    }
+
+    pub fn text(mut self, text: String) -> Self {
+        self.text = Some(text);
+        self
+    }
+
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filters.push(filter);
+        self
+    }
+
+    pub fn sort(mut self, sort: SortBy) -> Self {
+        self.sort = Some(sort);
+        self
+    }
+
+    pub fn page(mut self, page: Page) -> Self {
+        self.page = page;
+        self
+    }
+
+    pub fn build(self) -> Result<SearchQuery, BuildError> {
+        let text = self.text.ok_or(BuildError::MissingField("text"))?;
+
+        Ok(SearchQuery {
+            text,
+            filters: self.filters,
+            sort: self.sort,
+            page: self.page,
+        })
+    }
+}
+
+// 타입 상태 버전 (더 엄격)
+pub struct NoText;
+pub struct WithText;
+
+pub struct TypedSearchQueryBuilder<T> {
+    text: Option<String>,
+    filters: Vec<Filter>,
+    sort: Option<SortBy>,
+    page: Page,
+    _text_state: PhantomData<T>,
+}
+
+impl TypedSearchQueryBuilder<NoText> {
+    pub fn new() -> Self {
+        Self {
+            text: None,
+            filters: Vec::new(),
+            sort: None,
+            page: Page::default(),
+            _text_state: PhantomData,
+        }
+    }
+
+    pub fn text(self, text: String) -> TypedSearchQueryBuilder<WithText> {
+        TypedSearchQueryBuilder {
+            text: Some(text),
+            filters: self.filters,
+            sort: self.sort,
+            page: self.page,
+            _text_state: PhantomData,
+        }
+    }
+}
+
+impl<T> TypedSearchQueryBuilder<T> {
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filters.push(filter);
+        self
+    }
+
+    pub fn sort(mut self, sort: SortBy) -> Self {
+        self.sort = Some(sort);
+        self
+    }
+
+    pub fn page(mut self, page: Page) -> Self {
+        self.page = page;
+        self
+    }
+}
+
+impl TypedSearchQueryBuilder<WithText> {
+    pub fn build(self) -> SearchQuery {
+        SearchQuery {
+            text: self.text.unwrap(), // 안전
+            filters: self.filters,
+            sort: self.sort,
+            page: self.page,
+        }
+    }
+}
+```
+
+## 4. 트랜잭션 상태 관리
+
+```rust
+pub struct Transaction<State> {
+    id: String,
+    operations: Vec<Operation>,
+    _state: PhantomData<State>,
+}
+
+pub struct Started;
+pub struct Committed;
+pub struct RolledBack;
+
+impl Transaction<Started> {
+    pub fn begin(id: String) -> Self {
+        println!("Transaction {} started", id);
+        Self {
+            id,
+            operations: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+
+    pub fn execute(&mut self, op: Operation) -> Result<(), ExecutionError> {
+        println!("Executing operation in transaction {}", self.id);
+        self.operations.push(op);
+        Ok(())
+    }
+
+    pub fn commit(self) -> Result<Transaction<Committed>, CommitError> {
+        println!("Committing transaction {}", self.id);
+        // 커밋 로직
+        Ok(Transaction {
+            id: self.id,
+            operations: self.operations,
+            _state: PhantomData,
+        })
+    }
+
+    pub fn rollback(self) -> Transaction<RolledBack> {
+        println!("Rolling back transaction {}", self.id);
+        Transaction {
+            id: self.id,
+            operations: self.operations,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl Transaction<Committed> {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn operations(&self) -> &[Operation] {
+        &self.operations
+    }
+}
+
+impl Transaction<RolledBack> {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+// ✅ 사용 예시
+fn transaction_example() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tx = Transaction::begin("tx-001".to_string());
+
+    tx.execute(Operation::Insert)?;
+    tx.execute(Operation::Update)?;
+
+    let tx = tx.commit()?;
+
+    // ❌ 컴파일 에러: 이미 커밋된 트랜잭션은 execute 불가
+    // tx.execute(Operation::Delete)?;
+
+    println!("Transaction {} completed with {} operations", tx.id(), tx.operations().len());
+
+    Ok(())
+}
+```
+
+## 5. 권한 시스템
+
+```rust
+pub struct Permission<Level> {
+    user_id: String,
+    _level: PhantomData<Level>,
+}
+
+pub struct ReadOnly;
+pub struct ReadWrite;
+pub struct Admin;
+
+impl<Level> Permission<Level> {
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+}
+
+impl Permission<ReadOnly> {
+    pub fn read_only(user_id: String) -> Self {
+        Self {
+            user_id,
+            _level: PhantomData,
+        }
+    }
+
+    pub fn read(&self, resource: &Resource) -> Result<Data, PermissionError> {
+        println!("User {} reading resource", self.user_id);
+        Ok(Data::default())
+    }
+}
+
+impl Permission<ReadWrite> {
+    pub fn read_write(user_id: String) -> Self {
+        Self {
+            user_id,
+            _level: PhantomData,
+        }
+    }
+
+    pub fn read(&self, resource: &Resource) -> Result<Data, PermissionError> {
+        println!("User {} reading resource", self.user_id);
+        Ok(Data::default())
+    }
+
+    pub fn write(&self, resource: &Resource, data: &Data) -> Result<(), PermissionError> {
+        println!("User {} writing to resource", self.user_id);
+        Ok(())
+    }
+}
+
+impl Permission<Admin> {
+    pub fn admin(user_id: String) -> Self {
+        Self {
+            user_id,
+            _level: PhantomData,
+        }
+    }
+
+    pub fn read(&self, resource: &Resource) -> Result<Data, PermissionError> {
+        println!("Admin {} reading resource", self.user_id);
+        Ok(Data::default())
+    }
+
+    pub fn write(&self, resource: &Resource, data: &Data) -> Result<(), PermissionError> {
+        println!("Admin {} writing to resource", self.user_id);
+        Ok(())
+    }
+
+    pub fn delete(&self, resource: &Resource) -> Result<(), PermissionError> {
+        println!("Admin {} deleting resource", self.user_id);
+        Ok(())
+    }
+}
+
+// API 함수는 필요한 권한 레벨을 타입으로 명시
+pub fn view_document(perm: &Permission<ReadOnly>, doc_id: &str) -> Result<Document, Error> {
+    // ReadOnly 권한으로 충분
+    Ok(Document::default())
+}
+
+pub fn edit_document(perm: &Permission<ReadWrite>, doc_id: &str, content: &str) -> Result<(), Error> {
+    // ReadWrite 권한 필요
+    Ok(())
+}
+
+pub fn delete_document(perm: &Permission<Admin>, doc_id: &str) -> Result<(), Error> {
+    // Admin 권한 필요
+    Ok(())
+}
+
+// ✅ 사용 예시
+fn permission_example() {
+    let readonly = Permission::read_only("user1".to_string());
+    let readwrite = Permission::read_write("user2".to_string());
+    let admin = Permission::admin("admin1".to_string());
+
+    view_document(&readonly, "doc1"); // ✅ OK
+    // edit_document(&readonly, "doc1", "content"); // ❌ 컴파일 에러
+
+    edit_document(&readwrite, "doc1", "content"); // ✅ OK
+    // delete_document(&readwrite, "doc1"); // ❌ 컴파일 에러
+
+    delete_document(&admin, "doc1"); // ✅ OK
+}
+```
+
+## 6. 단계별 프로세스
+
+```rust
+pub struct OrderProcess<Stage> {
+    order_id: String,
+    _stage: PhantomData<Stage>,
+}
+
+pub struct Created;
+pub struct PaymentProcessed;
+pub struct Shipped;
+pub struct Delivered;
+
+impl OrderProcess<Created> {
+    pub fn create(order_id: String) -> Self {
+        Self {
+            order_id,
+            _stage: PhantomData,
+        }
+    }
+
+    pub fn process_payment(self) -> Result<OrderProcess<PaymentProcessed>, PaymentError> {
+        println!("Processing payment for order {}", self.order_id);
+        Ok(OrderProcess {
+            order_id: self.order_id,
+            _stage: PhantomData,
+        })
+    }
+}
+
+impl OrderProcess<PaymentProcessed> {
+    pub fn ship(self) -> OrderProcess<Shipped> {
+        println!("Shipping order {}", self.order_id);
+        OrderProcess {
+            order_id: self.order_id,
+            _stage: PhantomData,
+        }
+    }
+}
+
+impl OrderProcess<Shipped> {
+    pub fn deliver(self) -> OrderProcess<Delivered> {
+        println!("Delivering order {}", self.order_id);
+        OrderProcess {
+            order_id: self.order_id,
+            _stage: PhantomData,
+        }
+    }
+}
+
+impl OrderProcess<Delivered> {
+    pub fn complete(self) -> String {
+        println!("Order {} completed", self.order_id);
+        self.order_id
+    }
+}
+
+// ✅ 정해진 순서대로만 진행 가능
+fn order_example() -> Result<(), PaymentError> {
+    let order = OrderProcess::create("ORD-001".to_string());
+    let order = order.process_payment()?;
+    let order = order.ship();
+    let order = order.deliver();
+    let order_id = order.complete();
+
+    // ❌ 단계를 건너뛸 수 없음
+    // let order = OrderProcess::create("ORD-002".to_string());
+    // let order = order.ship(); // 컴파일 에러
+
+    Ok(())
+}
+```
+
+## 체크리스트
+
+타입 주도 설계 체크리스트:
+
+- [ ] 모순된 상태 조합이 타입으로 불가능하게 만들어졌는가?
+- [ ] Boolean 플래그 대신 enum 사용
+- [ ] Optional 필드들이 서로 관련 있으면 enum으로 묶기
+- [ ] 상태 전이를 타입으로 표현
+- [ ] Builder에 필수 필드를 타입으로 강제
+- [ ] 권한/단계를 타입 파라미터로 표현
+- [ ] API가 잘못된 사용을 컴파일 타임에 방지
+- [ ] PhantomData로 런타임 오버헤드 없음을 확인
+
+## 참고 자료
+
+- [Making Impossible States Impossible](https://www.youtube.com/watch?v=IcgmSRJHu_8)
+- [Type-Driven Development](https://blog.ploeh.dk/2015/08/10/type-driven-development/)
+- [The Typestate Pattern in Rust](http://cliffle.com/blog/rust-typestate/)

--- a/.claude/skills/rust-type-programming/guides/type-safety.md
+++ b/.claude/skills/rust-type-programming/guides/type-safety.md
@@ -1,0 +1,497 @@
+# 타입 안전성 가이드
+
+## 개요
+
+타입 안전성은 컴파일 타임에 오류를 방지하는 가장 강력한 도구입니다.
+엔터프라이즈 환경에서는 런타임 에러보다 컴파일 에러가 훨씬 저렴합니다.
+
+## 1. Newtype 패턴
+
+### 기본 원칙
+
+프리미티브 타입을 직접 사용하지 말고 도메인 의미를 담은 타입으로 래핑합니다.
+
+```rust
+// ❌ BAD: 프리미티브 타입 직접 사용
+fn transfer(from: String, to: String, amount: f64) -> Result<(), String> {
+    // from과 to를 실수로 바꿔서 호출할 수 있음
+    // amount가 음수일 수 있음
+}
+
+// ✅ GOOD: Newtype으로 타입 안전성 확보
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AccountId(String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Money {
+    cents: u64, // 음수 불가능, 소수점 오류 방지
+}
+
+impl Money {
+    pub fn from_dollars(dollars: u64) -> Self {
+        Self { cents: dollars * 100 }
+    }
+
+    pub fn from_cents(cents: u64) -> Self {
+        Self { cents }
+    }
+
+    pub fn cents(&self) -> u64 {
+        self.cents
+    }
+}
+
+fn transfer(from: AccountId, to: AccountId, amount: Money) -> Result<Receipt, TransferError> {
+    // 타입이 잘못된 사용을 방지
+    // from과 to를 바꿔서 호출하면 컴파일 에러는 아니지만,
+    // 명시적 타입으로 실수 가능성 감소
+}
+```
+
+### Validated Newtype
+
+생성자에서 유효성 검증을 강제합니다.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Email(String);
+
+#[derive(Debug, thiserror::Error)]
+pub enum EmailError {
+    #[error("Invalid email format: {0}")]
+    InvalidFormat(String),
+    #[error("Email too long: {0} characters")]
+    TooLong(usize),
+}
+
+impl Email {
+    const MAX_LENGTH: usize = 254;
+
+    /// 이메일을 생성합니다.
+    ///
+    /// # Errors
+    /// - 이메일 형식이 올바르지 않으면 `EmailError::InvalidFormat`
+    /// - 이메일이 254자를 초과하면 `EmailError::TooLong`
+    pub fn new(email: impl Into<String>) -> Result<Self, EmailError> {
+        let email = email.into();
+
+        if email.len() > Self::MAX_LENGTH {
+            return Err(EmailError::TooLong(email.len()));
+        }
+
+        if !email.contains('@') || !email.contains('.') {
+            return Err(EmailError::InvalidFormat(email));
+        }
+
+        Ok(Self(email))
+    }
+
+    /// # Safety
+    /// 이미 검증된 이메일로부터 생성합니다.
+    /// 외부 시스템에서 이미 검증된 경우에만 사용하세요.
+    pub fn new_unchecked(email: String) -> Self {
+        Self(email)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// ✅ 사용 예시
+fn send_email(to: Email, subject: &str, body: &str) -> Result<(), EmailSendError> {
+    // Email 타입을 받았다는 것은 이미 검증되었다는 보장
+    // 함수 내부에서 재검증 불필요
+}
+```
+
+### 단위 타입 (Units of Measure)
+
+```rust
+use std::marker::PhantomData;
+
+// 단위를 타입으로 표현
+pub struct Meters;
+pub struct Feet;
+pub struct Seconds;
+pub struct Hours;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Distance<Unit> {
+    value: f64,
+    _unit: PhantomData<Unit>,
+}
+
+impl Distance<Meters> {
+    pub fn meters(value: f64) -> Self {
+        Self {
+            value,
+            _unit: PhantomData,
+        }
+    }
+
+    pub fn to_feet(self) -> Distance<Feet> {
+        Distance {
+            value: self.value * 3.28084,
+            _unit: PhantomData,
+        }
+    }
+}
+
+impl Distance<Feet> {
+    pub fn feet(value: f64) -> Self {
+        Self {
+            value,
+            _unit: PhantomData,
+        }
+    }
+
+    pub fn to_meters(self) -> Distance<Meters> {
+        Distance {
+            value: self.value / 3.28084,
+            _unit: PhantomData,
+        }
+    }
+}
+
+// ✅ 타입 안전한 단위 변환
+fn calculate_distance() {
+    let d1 = Distance::meters(100.0);
+    let d2 = Distance::feet(328.084);
+
+    // 컴파일 에러: 다른 단위끼리 직접 비교 불가
+    // let same = d1 == d2;
+
+    // ✅ 명시적 변환 필요
+    let d2_in_meters = d2.to_meters();
+    let same = (d1.value - d2_in_meters.value).abs() < 0.001;
+}
+```
+
+## 2. Phantom Types
+
+컴파일 타임에만 존재하는 타입 정보로 상태를 표현합니다.
+
+```rust
+use std::marker::PhantomData;
+
+// 상태 타입들
+pub struct Open;
+pub struct Closed;
+pub struct Locked;
+
+pub struct Door<State> {
+    id: String,
+    _state: PhantomData<State>,
+}
+
+impl Door<Closed> {
+    pub fn new(id: String) -> Self {
+        Self {
+            id,
+            _state: PhantomData,
+        }
+    }
+
+    pub fn open(self) -> Door<Open> {
+        println!("Door {} is now open", self.id);
+        Door {
+            id: self.id,
+            _state: PhantomData,
+        }
+    }
+
+    pub fn lock(self) -> Door<Locked> {
+        println!("Door {} is now locked", self.id);
+        Door {
+            id: self.id,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl Door<Open> {
+    pub fn close(self) -> Door<Closed> {
+        println!("Door {} is now closed", self.id);
+        Door {
+            id: self.id,
+            _state: PhantomData,
+        }
+    }
+
+    // Open 상태에서는 lock 불가능 - 메서드 자체가 없음
+}
+
+impl Door<Locked> {
+    pub fn unlock(self) -> Door<Closed> {
+        println!("Door {} is now unlocked", self.id);
+        Door {
+            id: self.id,
+            _state: PhantomData,
+        }
+    }
+}
+
+// ✅ 타입 시스템이 불가능한 상태 전이를 방지
+fn door_example() {
+    let door = Door::new("main".to_string());
+    let door = door.open();
+    // let door = door.lock(); // ❌ 컴파일 에러: Open 상태에서 lock 불가
+    let door = door.close();
+    let door = door.lock(); // ✅ OK
+}
+```
+
+## 3. Builder 패턴의 타입 상태
+
+```rust
+use std::marker::PhantomData;
+
+// 빌더 상태
+pub struct WithoutName;
+pub struct WithName;
+pub struct WithoutEmail;
+pub struct WithEmail;
+
+pub struct UserBuilder<NameState, EmailState> {
+    name: Option<String>,
+    email: Option<String>,
+    age: Option<u32>,
+    _name_state: PhantomData<NameState>,
+    _email_state: PhantomData<EmailState>,
+}
+
+impl UserBuilder<WithoutName, WithoutEmail> {
+    pub fn new() -> Self {
+        Self {
+            name: None,
+            email: None,
+            age: None,
+            _name_state: PhantomData,
+            _email_state: PhantomData,
+        }
+    }
+}
+
+impl<EmailState> UserBuilder<WithoutName, EmailState> {
+    pub fn name(self, name: String) -> UserBuilder<WithName, EmailState> {
+        UserBuilder {
+            name: Some(name),
+            email: self.email,
+            age: self.age,
+            _name_state: PhantomData,
+            _email_state: PhantomData,
+        }
+    }
+}
+
+impl<NameState> UserBuilder<NameState, WithoutEmail> {
+    pub fn email(self, email: String) -> UserBuilder<NameState, WithEmail> {
+        UserBuilder {
+            name: self.name,
+            email: Some(email),
+            age: self.age,
+            _name_state: PhantomData,
+            _email_state: PhantomData,
+        }
+    }
+}
+
+impl<NameState, EmailState> UserBuilder<NameState, EmailState> {
+    pub fn age(mut self, age: u32) -> Self {
+        self.age = Some(age);
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct User {
+    name: String,
+    email: String,
+    age: Option<u32>,
+}
+
+// 필수 필드가 모두 설정된 경우에만 build 가능
+impl UserBuilder<WithName, WithEmail> {
+    pub fn build(self) -> User {
+        User {
+            name: self.name.unwrap(), // 타입 시스템이 Some 보장
+            email: self.email.unwrap(), // 타입 시스템이 Some 보장
+            age: self.age,
+        }
+    }
+}
+
+// ✅ 사용 예시
+fn builder_example() {
+    let user = UserBuilder::new()
+        .name("John".to_string())
+        .email("john@example.com".to_string())
+        .age(30)
+        .build(); // ✅ OK
+
+    // ❌ 컴파일 에러: name이 없음
+    // let user = UserBuilder::new()
+    //     .email("john@example.com".to_string())
+    //     .build();
+}
+```
+
+## 4. Non-Empty Collections
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonEmpty<T> {
+    head: T,
+    tail: Vec<T>,
+}
+
+impl<T> NonEmpty<T> {
+    /// 비어있지 않은 컬렉션을 생성합니다.
+    pub fn new(head: T, tail: Vec<T>) -> Self {
+        Self { head, tail }
+    }
+
+    /// 단일 요소로 NonEmpty를 생성합니다.
+    pub fn singleton(value: T) -> Self {
+        Self {
+            head: value,
+            tail: Vec::new(),
+        }
+    }
+
+    /// Vec로부터 NonEmpty를 생성합니다.
+    ///
+    /// # Returns
+    /// 비어있으면 None, 아니면 Some(NonEmpty)
+    pub fn from_vec(mut vec: Vec<T>) -> Option<Self> {
+        if vec.is_empty() {
+            None
+        } else {
+            let head = vec.remove(0);
+            Some(Self { head, tail: vec })
+        }
+    }
+
+    /// 첫 번째 요소를 반환합니다. (항상 존재함)
+    pub fn head(&self) -> &T {
+        &self.head
+    }
+
+    /// 길이를 반환합니다. (최소 1)
+    pub fn len(&self) -> usize {
+        1 + self.tail.len()
+    }
+
+    /// 요소를 추가합니다.
+    pub fn push(&mut self, value: T) {
+        self.tail.push(value);
+    }
+
+    /// 반복자를 반환합니다.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        std::iter::once(&self.head).chain(self.tail.iter())
+    }
+}
+
+// ✅ 비어있지 않음을 타입으로 보장
+fn process_items(items: NonEmpty<String>) -> String {
+    // unwrap 없이 안전하게 첫 번째 요소 접근
+    items.head().clone()
+}
+```
+
+## 5. 타입 레벨 불변조건
+
+```rust
+/// 정렬된 벡터를 보장하는 타입
+#[derive(Debug, Clone)]
+pub struct Sorted<T: Ord> {
+    inner: Vec<T>,
+}
+
+impl<T: Ord> Sorted<T> {
+    /// 정렬된 벡터를 생성합니다.
+    pub fn new(mut vec: Vec<T>) -> Self {
+        vec.sort();
+        Self { inner: vec }
+    }
+
+    /// 이미 정렬된 벡터로부터 생성합니다.
+    ///
+    /// # Safety
+    /// 호출자가 벡터가 정렬되어 있음을 보장해야 합니다.
+    pub fn new_unchecked(vec: Vec<T>) -> Self {
+        debug_assert!(vec.windows(2).all(|w| w[0] <= w[1]));
+        Self { inner: vec }
+    }
+
+    /// 이진 탐색을 수행합니다. (항상 O(log n))
+    pub fn binary_search(&self, value: &T) -> Result<usize, usize> {
+        self.inner.binary_search(value)
+    }
+
+    /// 요소를 정렬을 유지하며 삽입합니다.
+    pub fn insert(&mut self, value: T) {
+        match self.inner.binary_search(&value) {
+            Ok(pos) | Err(pos) => self.inner.insert(pos, value),
+        }
+    }
+
+    /// 내부 벡터에 대한 읽기 전용 참조
+    pub fn as_slice(&self) -> &[T] {
+        &self.inner
+    }
+}
+
+// ✅ 정렬 보장을 타입으로 표현
+fn find_in_sorted(items: &Sorted<i32>, target: i32) -> Option<usize> {
+    // 정렬되어 있음이 보장되므로 이진 탐색 안전
+    items.binary_search(&target).ok()
+}
+```
+
+## 6. Zero-Cost Abstractions 확인
+
+```rust
+// 타입 안전성이 런타임 비용을 추가하지 않는지 확인
+
+#[derive(Debug, Clone, Copy)]
+pub struct UserId(u64);
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProductId(u64);
+
+// 컴파일 후 어셈블리 확인:
+// cargo rustc --release -- --emit asm
+
+pub fn get_user(id: UserId) -> Option<String> {
+    // UserId는 런타임에 u64와 동일한 표현
+    // 추가 메모리나 연산 비용 없음
+    Some(format!("User {}", id.0))
+}
+
+// 두 함수의 어셈블리가 동일함을 확인
+pub fn get_user_primitive(id: u64) -> Option<String> {
+    Some(format!("User {}", id))
+}
+```
+
+## 체크리스트
+
+타입 안전성을 확보하기 위한 체크리스트:
+
+- [ ] String, i32, f64 등 프리미티브 타입을 직접 사용하지 않음
+- [ ] 모든 도메인 개념이 별도 타입으로 표현됨
+- [ ] Newtype 생성자에서 유효성 검증 수행
+- [ ] 불가능한 상태를 타입으로 표현 불가능하게 만듦
+- [ ] Builder에 타입 상태 적용
+- [ ] 컬렉션이 비어있으면 안 되는 경우 NonEmpty 사용
+- [ ] 타입 불변조건을 주석으로 문서화
+- [ ] Zero-cost abstraction 확인 (필요시 벤치마크)
+
+## 참고 자료
+
+- [Rust Design Patterns - Newtype](https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html)
+- [Parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)
+- [Making Impossible States Impossible](https://www.youtube.com/watch?v=IcgmSRJHu_8)


### PR DESCRIPTION
엔터프라이즈급 러스트 타입 프로그래밍 스킬 가이드를 추가합니다.

메인 스킬 파일:
- .claude/skills/rust-type-programming.md: 레퍼런스 중심의 메인 가이드

상세 가이드 문서:
- type-safety.md: Newtype 패턴, Phantom Types, 타입 레벨 불변조건
- error-handling.md: 커스텀 에러 타입, Result 체이닝, 컨텍스트 전파
- type-driven-design.md: Typestate 패턴, 불가능한 상태 제거
- generics-traits.md: 트레이트 바운드, Associated Types, Static/Dynamic Dispatch
- ownership-lifetimes.md: 소유권 패턴, 명시적 라이프타임, 스마트 포인터
- macros-codegen.md: Derive 매크로, 선언적 매크로, 컴파일 타임 검증

핵심 원칙:
- 타입 안전성 우선: 컴파일 타임에 최대한 많은 에러 방지
- 명시적 타입: 타입 추론보다 명시적 선언
- 불변성 기본: 가변성은 명시적으로만 사용
- 에러 타입화: 모든 에러를 타입으로 표현